### PR TITLE
Implement paginated cache endpoint

### DIFF
--- a/docs/project_description.md
+++ b/docs/project_description.md
@@ -22,6 +22,7 @@ O projeto é totalmente containerizado usando Docker. O `docker-compose.yml` orq
 - **Comparativo de Performance:** Existem endpoints equivalentes com e sem cache para permitir uma comparação direta do tempo de resposta.
 - **População de Dados:** Um script automatizado que popula a tabela principal com 250.000 registros de exemplo na inicialização da aplicação.
 - **Estratégias de Cache:** Demonstração do uso de anotações como `@Cacheable`, `@CacheEvict` e `@CachePut`.
+- **Consulta Paginada com Cache:** Endpoint `GET /produtos/com-cache` aceita parâmetros de paginação e armazena as páginas em cache.
 - **Testes Abrangentes:** O projeto incluirá testes de unidade e integração para validar o comportamento do cache (ex: hits, misses, evictions) e garantir a corretude da lógica de negócio.
 
 ## 4. Como Executar o Projeto

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -10,10 +10,10 @@ Esta lista documenta as tarefas planejadas e concluídas para o projeto `cache-w
 - [x] **#T4:** Implementar endpoint REST para buscar produtos sem cache (`GET /produtos/sem-cache/{id}`).
 - [x] **#T5:** Implementar endpoint REST para buscar produtos com cache (`GET /produtos/com-cache/{id}`).
 - [x] **#T6:** Criar um endpoint para atualizar um produto e invalidar seu cache (`PUT /produtos/{id}` com `@CacheEvict`).
+- [x] **#T7:** Implementar cache para consultas paginadas (`GET /produtos/com-cache`).
 
 ## A Fazer (Backlog)
 
-- [ ] **#T7:** Implementar cache para consultas paginadas (`GET /produtos/com-cache`).
 - [ ] **#T8:** Adicionar testes de carga (ex: com Gatling ou JMeter) para gerar um relatório de performance comparativo.
 - [ ] **#T9:** Documentar as estratégias de chave de cache (`KeyGenerator`) para cenários complexos.
 - [ ] **#T10:** Adicionar um endpoint para limpar todos os caches (`DELETE /cache/clear-all`).

--- a/src/main/java/com/example/cacheweb/controller/ProductController.java
+++ b/src/main/java/com/example/cacheweb/controller/ProductController.java
@@ -2,6 +2,8 @@ package com.example.cacheweb.controller;
 
 import com.example.cacheweb.model.Product;
 import com.example.cacheweb.service.ProductService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,6 +31,11 @@ public class ProductController {
         return service.findByIdCached(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/com-cache")
+    public Page<Product> findPagedCached(Pageable pageable) {
+        return service.findPagedCached(pageable);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/example/cacheweb/service/ProductService.java
+++ b/src/main/java/com/example/cacheweb/service/ProductService.java
@@ -4,6 +4,8 @@ import com.example.cacheweb.model.Product;
 import com.example.cacheweb.repository.ProductRepository;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -24,6 +26,11 @@ public class ProductService {
     @Cacheable("products")
     public Optional<Product> findByIdCached(Long id) {
         return repository.findById(id);
+    }
+
+    @Cacheable(value = "productsPage", key = "'page_' + #pageable.pageNumber + '_' + #pageable.pageSize")
+    public Page<Product> findPagedCached(Pageable pageable) {
+        return repository.findAll(pageable);
     }
 
     @CacheEvict(value = "products", key = "#product.id")

--- a/src/test/java/com/example/cacheweb/ProductServiceTest.java
+++ b/src/test/java/com/example/cacheweb/ProductServiceTest.java
@@ -28,4 +28,11 @@ class ProductServiceTest {
         Product updated = service.updateProduct(p);
         assertThat(updated.getName()).isEqualTo("Atualizado");
     }
+
+    @Test
+    void findPagedCachedReturnsPage() {
+        repository.save(new Product("Teste", BigDecimal.ONE));
+        var page = service.findPagedCached(org.springframework.data.domain.PageRequest.of(0, 10));
+        assertThat(page.getContent().size()).isGreaterThanOrEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary
- document completion of task T7 and describe new paginated endpoint
- add cached paginated query in ProductService
- expose `/produtos/com-cache` endpoint in controller
- test paginated query path

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68694f4804ac832e96b015890a92355d