### PR TITLE
docs: add performance tests instructions

### DIFF
--- a/docs/performance_tests.md
+++ b/docs/performance_tests.md
@@ -1,0 +1,28 @@
+# Testes de Carga (T8)
+
+Este documento descreve como executar testes de carga para comparar a performance dos endpoints com e sem cache.
+
+## Ferramenta Utilizada
+
+Foi utilizada a ferramenta **Apache JMeter** por ser simples de configurar e oferecer relatórios detalhados.
+
+## Arquivos de Teste
+
+O diretório `load-tests/` contém o arquivo `cache_test.jmx` com um plano de teste básico.
+
+## Como Executar
+
+1. Instale o JMeter de acordo com as instruções do site oficial.
+2. Inicie a infraestrutura do projeto:
+   ```bash
+   docker-compose up -d
+   ```
+3. Execute o plano de teste:
+   ```bash
+   jmeter -n -t load-tests/cache_test.jmx -l load-tests/result.jtl
+   ```
+4. Ao final do teste, abra o arquivo `result.jtl` no JMeter para visualizar os gráficos de performance.
+
+## Resultado Esperado
+
+Os endpoints com cache devem apresentar tempos de resposta significativamente menores após o primeiro acesso, demonstrando a eficiência da camada de cache.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ Esta lista documenta as tarefas planejadas e concluídas para o projeto `cache-w
 
 ## A Fazer (Backlog)
 
-- [ ] **#T8:** Adicionar testes de carga (ex: com Gatling ou JMeter) para gerar um relatório de performance comparativo.
+- [x] **#T8:** Adicionar testes de carga (ex: com Gatling ou JMeter) para gerar um relatório de performance comparativo.
 - [ ] **#T9:** Documentar as estratégias de chave de cache (`KeyGenerator`) para cenários complexos.
 - [ ] **#T10:** Adicionar um endpoint para limpar todos os caches (`DELETE /cache/clear-all`).
 - [ ] **#T11:** Implementar cache condicional com a anotação `@Cacheable(condition = "...")`.

--- a/load-tests/cache_test.jmx
+++ b/load-tests/cache_test.jmx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="CacheWeb Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true"/>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Default Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">10</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">0</longProp>
+        <longProp name="ThreadGroup.end_time">0</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Cached Endpoint" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.path">/produtos/com-cache/1</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Uncached Endpoint" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.path">/produtos/sem-cache/1</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
## Summary
- document how to run JMeter load tests
- provide a simple JMeter test plan example
- mark task T8 as completed

## Testing
- `./mvnw test` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869508cdaa0832e90be18f9c1ebaecc