### PR TITLE
Add advanced caching features

### DIFF
--- a/docs/key_generator.md
+++ b/docs/key_generator.md
@@ -1,0 +1,31 @@
+# Estratégias de KeyGenerator
+
+Este documento explica como personalizar a geração de chaves de cache para cenários mais complexos.
+
+## Motivação
+
+Em ambientes multi-tenant ou onde a chave de cache depende de múltiplos valores, o `KeyGenerator` padrão pode gerar colisões ou não refletir corretamente o contexto da aplicação.
+
+## Exemplo
+
+```java
+@Component("tenantKeyGenerator")
+public class TenantKeyGenerator implements KeyGenerator {
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        String tenantId = TenantContext.getCurrentTenant();
+        return tenantId + "_" + Arrays.toString(params);
+    }
+}
+```
+
+Utilize o gerador com a anotação `@Cacheable`:
+
+```java
+@Cacheable(value = "products", keyGenerator = "tenantKeyGenerator")
+public Optional<Product> findByIdTenantAware(Long id) {
+    return repository.findById(id);
+}
+```
+
+Este esquema garante que as chaves de cache sejam únicas por `tenant`.

--- a/docs/project_description.md
+++ b/docs/project_description.md
@@ -21,8 +21,10 @@ O projeto é totalmente containerizado usando Docker. O `docker-compose.yml` orq
 - **API REST:** Endpoints para consultar dados de uma entidade principal.
 - **Comparativo de Performance:** Existem endpoints equivalentes com e sem cache para permitir uma comparação direta do tempo de resposta.
 - **População de Dados:** Um script automatizado que popula a tabela principal com 250.000 registros de exemplo na inicialização da aplicação.
-- **Estratégias de Cache:** Demonstração do uso de anotações como `@Cacheable`, `@CacheEvict` e `@CachePut`.
+- **Estratégias de Cache:** Demonstração do uso de anotações como `@Cacheable`, `@CacheEvict` e `@CachePut`. Consulte `docs/key_generator.md` para exemplos avançados de `KeyGenerator`.
 - **Consulta Paginada com Cache:** Endpoint `GET /produtos/com-cache` aceita parâmetros de paginação e armazena as páginas em cache.
+- **Limpeza de Cache:** Endpoint `DELETE /cache/clear-all` permite esvaziar todos os caches.
+- **Cache Condicional:** Uso de `@Cacheable(condition = "...")` para cenários onde o cache só deve ser ativado sob determinadas condições.
 - **Testes Abrangentes:** O projeto incluirá testes de unidade e integração para validar o comportamento do cache (ex: hits, misses, evictions) e garantir a corretude da lógica de negócio.
 
 ## 4. Como Executar o Projeto

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -15,6 +15,6 @@ Esta lista documenta as tarefas planejadas e concluídas para o projeto `cache-w
 ## A Fazer (Backlog)
 
 - [x] **#T8:** Adicionar testes de carga (ex: com Gatling ou JMeter) para gerar um relatório de performance comparativo.
-- [ ] **#T9:** Documentar as estratégias de chave de cache (`KeyGenerator`) para cenários complexos.
-- [ ] **#T10:** Adicionar um endpoint para limpar todos os caches (`DELETE /cache/clear-all`).
-- [ ] **#T11:** Implementar cache condicional com a anotação `@Cacheable(condition = "...")`.
+- [x] **#T9:** Documentar as estratégias de chave de cache (`KeyGenerator`) para cenários complexos.
+- [x] **#T10:** Adicionar um endpoint para limpar todos os caches (`DELETE /cache/clear-all`).
+- [x] **#T11:** Implementar cache condicional com a anotação `@Cacheable(condition = "...")`.

--- a/src/main/java/com/example/cacheweb/controller/CacheController.java
+++ b/src/main/java/com/example/cacheweb/controller/CacheController.java
@@ -1,0 +1,30 @@
+package com.example.cacheweb.controller;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cache")
+public class CacheController {
+
+    private final CacheManager cacheManager;
+
+    public CacheController(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @DeleteMapping("/clear-all")
+    public ResponseEntity<Void> clearAll() {
+        for (String name : cacheManager.getCacheNames()) {
+            Cache cache = cacheManager.getCache(name);
+            if (cache != null) {
+                cache.clear();
+            }
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/cacheweb/controller/ProductController.java
+++ b/src/main/java/com/example/cacheweb/controller/ProductController.java
@@ -33,6 +33,13 @@ public class ProductController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/condicional/{id}")
+    public ResponseEntity<Product> findConditional(@PathVariable Long id) {
+        return service.findByIdConditional(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @GetMapping("/com-cache")
     public Page<Product> findPagedCached(Pageable pageable) {
         return service.findPagedCached(pageable);

--- a/src/main/java/com/example/cacheweb/service/ProductService.java
+++ b/src/main/java/com/example/cacheweb/service/ProductService.java
@@ -28,6 +28,11 @@ public class ProductService {
         return repository.findById(id);
     }
 
+    @Cacheable(value = "products", key = "#id", condition = "#id > 1000")
+    public Optional<Product> findByIdConditional(Long id) {
+        return repository.findById(id);
+    }
+
     @Cacheable(value = "productsPage", key = "'page_' + #pageable.pageNumber + '_' + #pageable.pageSize")
     public Page<Product> findPagedCached(Pageable pageable) {
         return repository.findAll(pageable);

--- a/src/test/java/com/example/cacheweb/ProductServiceTest.java
+++ b/src/test/java/com/example/cacheweb/ProductServiceTest.java
@@ -35,4 +35,11 @@ class ProductServiceTest {
         var page = service.findPagedCached(org.springframework.data.domain.PageRequest.of(0, 10));
         assertThat(page.getContent().size()).isGreaterThanOrEqualTo(1);
     }
+
+    @Test
+    void findByIdConditionalReturnsProduct() {
+        Product p = repository.save(new Product("Teste", BigDecimal.ONE));
+        var result = service.findByIdConditional(p.getId());
+        assertThat(result).isPresent();
+    }
 }


### PR DESCRIPTION
## Summary
- document cache key strategies using custom `KeyGenerator`
- add endpoint to clear all caches
- implement conditional caching example
- describe new features in documentation
- expand unit tests

## Testing
- `./mvnw test -q` *(fails: Could not transfer artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_686951b032c8832ea443108d2fa21469